### PR TITLE
Fix ingest script to rebuild index successfully

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""Local RAG Chatbot package."""
+
+# This module intentionally left blank. It only exists so that ``app``
+# resolves as a proper package when ``app/main.py`` is executed directly
+# via ``python path/to/app/main.py``.

--- a/app/ingest.py
+++ b/app/ingest.py
@@ -1,90 +1,89 @@
-
 import argparse
 import json
 import os
 import re
 from pathlib import Path
-from typing import List, Dict
+from typing import List
 
-from pdfminer.high_level import extract_text as pdf_extract_text
 from docx import Document
-
-# Einfache Satz- und Token-Funktionen ohne NLTK
-_SENT_SPLIT = re.compile(r'(?<=[.!?])\s+(?=[A-ZÄÖÜ0-9])')
-_WORD_SPLIT = re.compile(r"[^a-zA-Z0-9äöüÄÖÜß]+")
+from pdfminer.high_level import extract_text as pdf_extract_text
 
 
-def read_text_file(p: Path) -> str:
+PARAGRAPH_SPLIT_RE = re.compile(r"\n\s*\n+")
+
+
+def read_text_file(path: Path) -> str:
     try:
-        return p.read_text(encoding='utf-8')
+        return path.read_text(encoding="utf-8")
     except UnicodeDecodeError:
-        return p.read_text(encoding='latin-1', errors='ignore')
+        return path.read_text(encoding="latin-1", errors="ignore")
 
 
-def read_pdf_file(p: Path) -> str:
+def read_pdf_file(path: Path) -> str:
     try:
-        return pdf_extract_text(str(p))
-    except Exception as e:
+        return pdf_extract_text(str(path))
+    except Exception:
         return ""
 
 
-def read_docx_file(p: Path) -> str:
+def read_docx_file(path: Path) -> str:
     try:
-        doc = Document(str(p))
-        return "
-".join([para.text for para in doc.paragraphs])
+        document = Document(str(path))
+        return "\n".join(para.text for para in document.paragraphs)
     except Exception:
         return ""
 
 
 def split_into_chunks(text: str, chunk_size: int, overlap: int) -> List[str]:
-    # Paragraphen-orientiert, fallback auf sliding window
-    paragraphs = [t.strip() for t in re.split(r"
-\s*
-+", text) if t.strip()]
+    paragraphs = [p.strip() for p in PARAGRAPH_SPLIT_RE.split(text) if p.strip()]
+    if not paragraphs:
+        paragraphs = [text.strip()]
+
     chunks: List[str] = []
-    for para in paragraphs:
-        if len(para) <= chunk_size:
-            chunks.append(para)
-        else:
-            start = 0
-            while start < len(para):
-                end = min(start + chunk_size, len(para))
-                chunks.append(para[start:end])
-                if end == len(para):
-                    break
+    for paragraph in paragraphs:
+        if len(paragraph) <= chunk_size:
+            chunks.append(paragraph)
+            continue
+
+        start = 0
+        text_length = len(paragraph)
+        while start < text_length:
+            end = min(start + chunk_size, text_length)
+            chunks.append(paragraph[start:end])
+            if end == text_length:
+                break
+            if overlap >= chunk_size:
+                start = end
+            else:
                 start = max(end - overlap, 0)
     return chunks
 
 
-def detect_pages_for_pdf(text: str) -> List[int]:
-    # pdfminer liefert Fließtext; ohne Layout nehmen wir Seite unbekannt => -1
-    return []
-
-
 def ingest(data_dir: str, index_path: str, chunk_size: int = 800, overlap: int = 120) -> int:
-    root = Path(data_dir)
-    idx_path = Path(index_path)
-    idx_path.parent.mkdir(parents=True, exist_ok=True)
+    data_root = Path(data_dir)
+    index_file = Path(index_path)
+    index_file.parent.mkdir(parents=True, exist_ok=True)
 
-    supported = {'.txt', '.md', '.pdf', '.docx'}
-    count = 0
-    with open(idx_path, 'w', encoding='utf-8') as out:
-        for p in root.rglob('*'):
-            if not p.is_file():
-                continue
-            ext = p.suffix.lower()
-            if ext not in supported:
+    supported_extensions = {".txt", ".md", ".pdf", ".docx"}
+    chunk_count = 0
+
+    with index_file.open("w", encoding="utf-8") as handle:
+        for path in data_root.rglob("*"):
+            if not path.is_file():
                 continue
 
-            if ext in {'.txt', '.md'}:
-                text = read_text_file(p)
+            extension = path.suffix.lower()
+            if extension not in supported_extensions:
+                continue
+
+            if extension in {".txt", ".md"}:
+                text = read_text_file(path)
                 page_info = None
-            elif ext == '.pdf':
-                text = read_pdf_file(p)
-                page_info = None  # Unknown page mapping
-            elif ext == '.docx':
-                text = read_docx_file(p)
+            elif extension == ".pdf":
+                text = read_pdf_file(path)
+                page_info = None
+            elif extension == ".docx":
+                text = read_docx_file(path)
                 page_info = None
             else:
                 continue
@@ -92,36 +91,36 @@ def ingest(data_dir: str, index_path: str, chunk_size: int = 800, overlap: int =
             if not text or not text.strip():
                 continue
 
-            chunks = split_into_chunks(text, chunk_size, overlap)
-            for i, ch in enumerate(chunks):
-                rec = {
-                    'id': f"{p.name}:{i}",
-                    'text': ch,
-                    'source_path': str(p),
-                    'source_name': p.name,
-                    'page': page_info if page_info is not None else None,
-                    'chunk_idx': i,
+            for idx, chunk in enumerate(split_into_chunks(text, chunk_size, overlap)):
+                record = {
+                    "id": f"{path.name}:{idx}",
+                    "text": chunk,
+                    "source_path": str(path),
+                    "source_name": path.name,
+                    "page": page_info,
+                    "chunk_idx": idx,
                 }
-                out.write(json.dumps(rec, ensure_ascii=False) + "
-")
-                count += 1
-    return count
+                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+                chunk_count += 1
+
+    return chunk_count
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    ap.add_argument('--data-dir', default='data')
-    ap.add_argument('--index-path', default='index.jsonl')
-    ap.add_argument('--chunk-size', type=int, default=800)
-    ap.add_argument('--overlap', type=int, default=120)
-    ap.add_argument('--reset', action='store_true')
-    args = ap.parse_args()
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", default="data")
+    parser.add_argument("--index-path", default="index.jsonl")
+    parser.add_argument("--chunk-size", type=int, default=800)
+    parser.add_argument("--overlap", type=int, default=120)
+    parser.add_argument("--reset", action="store_true")
+    args = parser.parse_args()
 
     if args.reset and os.path.exists(args.index_path):
         os.remove(args.index_path)
 
-    n = ingest(args.data_dir, args.index_path, args.chunk_size, args.overlap)
-    print(f"Index erstellt: {n} Chunks -> {args.index_path}")
+    total = ingest(args.data_dir, args.index_path, args.chunk_size, args.overlap)
+    print(f"Index erstellt: {total} Chunks -> {args.index_path}")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/app/ingest.py
+++ b/app/ingest.py
@@ -3,60 +3,160 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import List
+from typing import Iterable, List, Optional, Tuple
 
 from docx import Document
-from pdfminer.high_level import extract_text as pdf_extract_text
+from pdfminer.high_level import extract_pages, extract_text as pdf_extract_text
+from pdfminer.layout import LTTextContainer
 
 
 PARAGRAPH_SPLIT_RE = re.compile(r"\n\s*\n+")
+SINGLE_NEWLINE_RE = re.compile(r"(?<!\n)\n(?!\n)")
+WHITESPACE_RE = re.compile(r"[ \t\f\v]+")
+
+
+def normalize_text(text: str) -> str:
+    """Collapse whitespace, remove soft hyphenation and join short lines."""
+
+    if not text:
+        return ""
+
+    text = text.replace("\ufeff", "")
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = text.replace("\u00ad", "")  # soft hyphen
+    text = re.sub(r"-\s*\n", "", text)  # unwrap hyphenated line breaks
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    text = WHITESPACE_RE.sub(" ", text)
+    text = SINGLE_NEWLINE_RE.sub(" ", text)
+    paragraphs = [p.strip() for p in PARAGRAPH_SPLIT_RE.split(text) if p.strip()]
+    if not paragraphs:
+        return text.strip()
+    return "\n\n".join(paragraphs)
 
 
 def read_text_file(path: Path) -> str:
     try:
-        return path.read_text(encoding="utf-8")
+        raw = path.read_text(encoding="utf-8")
     except UnicodeDecodeError:
-        return path.read_text(encoding="latin-1", errors="ignore")
-
-
-def read_pdf_file(path: Path) -> str:
-    try:
-        return pdf_extract_text(str(path))
-    except Exception:
-        return ""
+        raw = path.read_text(encoding="latin-1", errors="ignore")
+    return normalize_text(raw)
 
 
 def read_docx_file(path: Path) -> str:
     try:
         document = Document(str(path))
-        return "\n".join(para.text for para in document.paragraphs)
     except Exception:
         return ""
+    text = "\n".join(para.text for para in document.paragraphs)
+    return normalize_text(text)
+
+
+def read_pdf_file(path: Path) -> List[Tuple[Optional[int], str]]:
+    pages: List[Tuple[Optional[int], str]] = []
+    try:
+        for page_number, layout in enumerate(extract_pages(str(path)), start=1):
+            segments: List[str] = []
+            for element in layout:
+                if isinstance(element, LTTextContainer):
+                    segments.append(element.get_text())
+            page_text = normalize_text("\n".join(segments))
+            if page_text:
+                pages.append((page_number, page_text))
+    except Exception:
+        pages = []
+
+    if pages:
+        return pages
+
+    # Fallback: best-effort plain text extraction if layout parsing fails
+    try:
+        fallback_text = normalize_text(pdf_extract_text(str(path)))
+    except Exception:
+        fallback_text = ""
+    return [(None, fallback_text)] if fallback_text else []
+
+
+def chunk_text(text: str, chunk_size: int, overlap: int) -> List[str]:
+    if not text:
+        return []
+
+    text = text.strip()
+    if not text:
+        return []
+
+    chunks: List[str] = []
+    total_length = len(text)
+    start = 0
+    previous_start = -1
+
+    while start < total_length and start != previous_start:
+        previous_start = start
+        end = min(start + chunk_size, total_length)
+
+        if end < total_length:
+            split = _find_split_position(text, start, end)
+            if split is not None and split > start:
+                end = split
+
+        chunk = text[start:end].strip()
+        if chunk:
+            chunks.append(chunk)
+
+        if end >= total_length:
+            break
+
+        if overlap >= chunk_size:
+            next_start = end
+        else:
+            next_start = max(end - overlap, 0)
+
+        while next_start > start and next_start > 0 and not text[next_start - 1].isspace():
+            next_start -= 1
+        while next_start < total_length and text[next_start].isspace():
+            next_start += 1
+
+        if next_start <= start:
+            next_start = end
+
+        start = next_start
+
+    return chunks
+
+
+def _find_split_position(text: str, start: int, end: int) -> Optional[int]:
+    window = text[start:end]
+    patterns: Iterable[Tuple[str, int]] = [
+        ("\n\n", 0),
+        (". ", 1),
+        ("? ", 1),
+        ("! ", 1),
+        ("\n", 0),
+        (" ", 0),
+    ]
+
+    for pattern, offset in patterns:
+        idx = window.rfind(pattern)
+        if idx > 0:
+            return start + idx + offset
+    return None
 
 
 def split_into_chunks(text: str, chunk_size: int, overlap: int) -> List[str]:
-    paragraphs = [p.strip() for p in PARAGRAPH_SPLIT_RE.split(text) if p.strip()]
-    if not paragraphs:
-        paragraphs = [text.strip()]
+    normalized = normalize_text(text)
+    return chunk_text(normalized, chunk_size, overlap)
 
-    chunks: List[str] = []
-    for paragraph in paragraphs:
-        if len(paragraph) <= chunk_size:
-            chunks.append(paragraph)
-            continue
 
-        start = 0
-        text_length = len(paragraph)
-        while start < text_length:
-            end = min(start + chunk_size, text_length)
-            chunks.append(paragraph[start:end])
-            if end == text_length:
-                break
-            if overlap >= chunk_size:
-                start = end
-            else:
-                start = max(end - overlap, 0)
-    return chunks
+def load_sections(path: Path) -> List[Tuple[Optional[int], str]]:
+    extension = path.suffix.lower()
+    if extension in {".txt", ".md"}:
+        text = read_text_file(path)
+        return [(None, text)] if text else []
+    if extension == ".docx":
+        text = read_docx_file(path)
+        return [(None, text)] if text else []
+    if extension == ".pdf":
+        return read_pdf_file(path)
+    return []
 
 
 def ingest(data_dir: str, index_path: str, chunk_size: int = 800, overlap: int = 120) -> int:
@@ -64,45 +164,41 @@ def ingest(data_dir: str, index_path: str, chunk_size: int = 800, overlap: int =
     index_file = Path(index_path)
     index_file.parent.mkdir(parents=True, exist_ok=True)
 
-    supported_extensions = {".txt", ".md", ".pdf", ".docx"}
+    tmp_path = (
+        index_file.with_suffix(index_file.suffix + ".tmp")
+        if index_file.suffix
+        else index_file.with_name(index_file.name + ".tmp")
+    )
+    if tmp_path.exists():
+        tmp_path.unlink()
+
     chunk_count = 0
 
-    with index_file.open("w", encoding="utf-8") as handle:
-        for path in data_root.rglob("*"):
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        for path in sorted(data_root.rglob("*")):
             if not path.is_file():
                 continue
 
-            extension = path.suffix.lower()
-            if extension not in supported_extensions:
+            sections = load_sections(path)
+            if not sections:
                 continue
 
-            if extension in {".txt", ".md"}:
-                text = read_text_file(path)
-                page_info = None
-            elif extension == ".pdf":
-                text = read_pdf_file(path)
-                page_info = None
-            elif extension == ".docx":
-                text = read_docx_file(path)
-                page_info = None
-            else:
-                continue
+            chunk_idx = 0
+            for page_info, section_text in sections:
+                for chunk in split_into_chunks(section_text, chunk_size, overlap):
+                    record = {
+                        "id": f"{path.name}:{chunk_idx}",
+                        "text": chunk,
+                        "source_path": str(path),
+                        "source_name": path.name,
+                        "page": page_info,
+                        "chunk_idx": chunk_idx,
+                    }
+                    handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+                    chunk_count += 1
+                    chunk_idx += 1
 
-            if not text or not text.strip():
-                continue
-
-            for idx, chunk in enumerate(split_into_chunks(text, chunk_size, overlap)):
-                record = {
-                    "id": f"{path.name}:{idx}",
-                    "text": chunk,
-                    "source_path": str(path),
-                    "source_name": path.name,
-                    "page": page_info,
-                    "chunk_idx": idx,
-                }
-                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
-                chunk_count += 1
-
+    tmp_path.replace(index_file)
     return chunk_count
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,20 @@
+from pathlib import Path
+import sys
+
+# Allow running this module directly (e.g. ``python app/main.py``) by ensuring
+# the repository root is on ``sys.path`` so ``import app`` works even when
+# Python sets ``__package__`` to ``None``.
+if __package__ is None or __package__ == "":  # pragma: no cover - runtime setup
+    package_dir = Path(__file__).resolve().parent
+    project_root = package_dir.parent
+    if str(project_root) not in sys.path:
+        sys.path.insert(0, str(project_root))
+
 from flask import Flask, request, jsonify, render_template
-import os
 
 from app.config import HOST, PORT, DATA_DIR, INDEX_PATH
-from .retriever import Retriever
-from .chat import ChatEngine
+from app.retriever import Retriever
+from app.chat import ChatEngine
 
 app = Flask(__name__, template_folder='templates', static_folder='static')
 
@@ -28,9 +39,9 @@ def api_chat():
 @app.post('/api/reindex')
 def api_reindex():
     # Lazy import to avoid cost at import time
-    from .ingest import ingest
+    from app.ingest import ingest
     # Env gesteuert
-    from .config import CHUNK_SIZE, CHUNK_OVERLAP
+    from app.config import CHUNK_SIZE, CHUNK_OVERLAP
     n = ingest(DATA_DIR, INDEX_PATH, CHUNK_SIZE, CHUNK_OVERLAP)
     retriever.reload()
     return jsonify({"indexed_chunks": n})

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -6,9 +6,14 @@ h1 { margin: 0 0 8px; font-size: 24px; }
 .muted { color: #94a3b8; margin: 0 0 16px; }
 #chat { background: #111827; border: 1px solid #1f2937; border-radius: 8px; padding: 16px; }
 #messages { height: 50vh; overflow: auto; padding: 8px; background: #0b1220; border-radius: 6px; border: 1px solid #1f2937; }
-.msg { padding: 10px 12px; margin: 8px 0; border-radius: 6px; white-space: pre-wrap; }
+.msg { padding: 12px 14px; margin: 8px 0; border-radius: 6px; display: flex; flex-direction: column; gap: 8px; }
 .msg.user { background: #1e293b; }
 .msg.assistant { background: #0b3b24; }
+.msg.pending { opacity: 0.7; }
+.msg.error { background: #7f1d1d; }
+.msg-text { white-space: pre-wrap; line-height: 1.4; }
+.citations { margin: 0; padding-left: 20px; font-size: 14px; color: #a7f3d0; }
+.citations li { margin-bottom: 4px; }
 #form { display: flex; gap: 8px; margin-top: 10px; }
 #input { flex: 1; padding: 10px; border-radius: 6px; border: 1px solid #334155; background: #0b1220; color: #e2e8f0; }
 button { background: #2563eb; color: white; border: none; padding: 10px 16px; border-radius: 6px; cursor: pointer; }

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -33,75 +33,192 @@
     const messages = document.getElementById('messages');
     const form = document.getElementById('form');
     const input = document.getElementById('input');
+    const sendButton = form.querySelector('button[type="submit"]');
+    const conversation = [];
+    const MAX_HISTORY = 20;
 
-    function addMessage(role, content) {
-      const div = document.createElement('div');
-      div.className = 'msg ' + role;
-      div.textContent = content;
-      messages.appendChild(div);
+    function scrollToBottom() {
       messages.scrollTop = messages.scrollHeight;
     }
 
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const text = input.value.trim();
-      if (!text) return;
-      addMessage('user', text);
-      input.value = '';
-
-      try {
-        const resp = await fetch('/api/chat', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ message: text, history: [] }),
-        });
-        if (!resp.ok) {
-          throw new Error(`HTTP ${resp.status}`);
-        }
-        const data = await resp.json();
-        const answer = data.answer || '';
-        const cites = Array.isArray(data.citations) ? data.citations : [];
-        let citeText = '';
-        if (cites.length) {
-          const citeLines = cites.map((c, i) => {
-            const parts = [`[${i + 1}] ${c.source_name || 'Quelle'}`];
-            if (typeof c.page === 'number') {
-              parts.push(`Seite ${c.page}`);
-            }
-            if (typeof c.score === 'number' && !Number.isNaN(c.score)) {
-              parts.push(`Score: ${Number(c.score).toFixed(2)}`);
-            }
-            return parts.join(' | ');
-          }).join('\n');
-          citeText = `\n\nQuellen:\n${citeLines}`;
-        }
-        addMessage('assistant', answer + citeText);
-      } catch (err) {
-        console.error(err);
-        addMessage('assistant', 'Es ist ein Fehler beim Abrufen der Antwort aufgetreten. Siehe Konsole für Details.');
+    function trimHistory() {
+      while (conversation.length > MAX_HISTORY) {
+        conversation.shift();
       }
+    }
+
+    function createMessageElement(role, content) {
+      const entry = document.createElement('div');
+      entry.className = 'msg ' + role;
+
+      const textBlock = document.createElement('div');
+      textBlock.className = 'msg-text';
+      textBlock.textContent = content;
+      entry.appendChild(textBlock);
+
+      if (role === 'assistant') {
+        const citeList = document.createElement('ol');
+        citeList.className = 'citations';
+        citeList.style.display = 'none';
+        entry.appendChild(citeList);
+      }
+
+      messages.appendChild(entry);
+      scrollToBottom();
+      return entry;
+    }
+
+    function updateAssistantMessage(entry, text, citations) {
+      const textBlock = entry.querySelector('.msg-text');
+      if (textBlock) {
+        textBlock.textContent = text;
+      }
+      const citeList = entry.querySelector('.citations');
+      if (!citeList) {
+        return;
+      }
+      citeList.innerHTML = '';
+      if (!Array.isArray(citations) || !citations.length) {
+        citeList.style.display = 'none';
+        return;
+      }
+
+      citations.forEach((c, index) => {
+        const li = document.createElement('li');
+        const parts = [`[${index + 1}] ${c && c.source_name ? c.source_name : 'Quelle'}`];
+        if (c && typeof c.page === 'number') {
+          parts.push(`Seite ${c.page}`);
+        }
+        if (c && typeof c.score === 'number' && !Number.isNaN(c.score)) {
+          parts.push(`Score ${Number(c.score).toFixed(2)}`);
+        }
+        li.textContent = parts.join(' • ');
+        citeList.appendChild(li);
+      });
+      citeList.style.display = '';
+    }
+
+    function setUiBusy(busy) {
+      input.disabled = busy;
+      sendButton.disabled = busy;
+      form.classList.toggle('busy', busy);
+    }
+
+    function postJson(url, payload) {
+      const body = JSON.stringify(payload !== undefined ? payload : {});
+      const headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      };
+
+      if (window.fetch) {
+        return fetch(url, {
+          method: 'POST',
+          headers,
+          body,
+        }).then((resp) => {
+          if (!resp.ok) {
+            return resp.text().then((text) => {
+              const err = new Error(`HTTP ${resp.status}${text ? ` – ${text}` : ''}`);
+              err.status = resp.status;
+              throw err;
+            });
+          }
+          return resp.json();
+        });
+      }
+
+      return new Promise((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open('POST', url, true);
+        Object.keys(headers).forEach((key) => {
+          xhr.setRequestHeader(key, headers[key]);
+        });
+        xhr.onreadystatechange = () => {
+          if (xhr.readyState !== 4) {
+            return;
+          }
+          if (xhr.status >= 200 && xhr.status < 300) {
+            try {
+              const data = JSON.parse(xhr.responseText || '{}');
+              resolve(data);
+            } catch (parseErr) {
+              reject(parseErr);
+            }
+          } else {
+            reject(new Error(`HTTP ${xhr.status}`));
+          }
+        };
+        xhr.onerror = () => reject(new Error('Netzwerkfehler'));
+        xhr.send(body);
+      });
+    }
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const text = input.value.trim();
+      if (!text) {
+        return;
+      }
+
+      input.value = '';
+      createMessageElement('user', text);
+
+      conversation.push({ role: 'user', content: text });
+      trimHistory();
+
+      const assistantEntry = createMessageElement('assistant', '…');
+      assistantEntry.classList.add('pending');
+
+      const historyPayload = conversation.slice(0, Math.max(conversation.length - 1, 0));
+
+      setUiBusy(true);
+
+      postJson('/api/chat', { message: text, history: historyPayload })
+        .then((data) => {
+          const answer = typeof data.answer === 'string' && data.answer.trim()
+            ? data.answer
+            : 'Keine Antwort erhalten.';
+          const citations = Array.isArray(data.citations) ? data.citations : [];
+          updateAssistantMessage(assistantEntry, answer, citations);
+          assistantEntry.classList.remove('pending');
+          conversation.push({ role: 'assistant', content: answer });
+          trimHistory();
+        })
+        .catch((err) => {
+          console.error(err);
+          const message = 'Fehler beim Abrufen der Antwort: ' + (err && err.message ? err.message : err);
+          updateAssistantMessage(assistantEntry, message, []);
+          assistantEntry.classList.remove('pending');
+          assistantEntry.classList.add('error');
+        })
+        .finally(() => {
+          setUiBusy(false);
+          input.focus();
+        });
     });
 
     const reindexButton = document.getElementById('reindex');
     const reindexStatus = document.getElementById('reindex-status');
-    reindexButton.addEventListener('click', async () => {
+    reindexButton.addEventListener('click', () => {
       reindexButton.disabled = true;
       reindexStatus.textContent = '… läuft';
-      try {
-        const resp = await fetch('/api/reindex', { method: 'POST' });
-        if (!resp.ok) {
-          throw new Error(`HTTP ${resp.status}`);
-        }
-        const data = await resp.json();
-        const total = typeof data.indexed_chunks === 'number' ? data.indexed_chunks : '–';
-        reindexStatus.textContent = `OK – ${total} Chunks`;
-      } catch (err) {
-        console.error(err);
-        reindexStatus.textContent = 'Fehler beim Reindex – siehe Konsole';
-      } finally {
-        reindexButton.disabled = false;
-      }
+
+      postJson('/api/reindex', {})
+        .then((data) => {
+          const total = typeof data.indexed_chunks === 'number' ? data.indexed_chunks : '–';
+          reindexStatus.textContent = `OK – ${total} Chunks`;
+        })
+        .catch((err) => {
+          console.error(err);
+          reindexStatus.textContent = 'Fehler beim Reindex – ' + (err && err.message ? err.message : err);
+        })
+        .finally(() => {
+          reindexButton.disabled = false;
+        });
     });
+
+    input.focus();
   </script>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -49,30 +49,58 @@
       addMessage('user', text);
       input.value = '';
 
-      const resp = await fetch('/api/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: text, history: [] }),
-      });
-      const data = await resp.json();
-      const answer = data.answer || '';
-      const cites = data.citations || [];
-      let citeText = '';
-      if (cites.length) {
-        citeText = '
-
-Quellen:
-' + cites.map((c, i) => ` [${i+1}] ${c.source_name} (Score: ${c.score.toFixed(2)})`).join('
-');
+      try {
+        const resp = await fetch('/api/chat', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: text, history: [] }),
+        });
+        if (!resp.ok) {
+          throw new Error(`HTTP ${resp.status}`);
+        }
+        const data = await resp.json();
+        const answer = data.answer || '';
+        const cites = Array.isArray(data.citations) ? data.citations : [];
+        let citeText = '';
+        if (cites.length) {
+          const citeLines = cites.map((c, i) => {
+            const parts = [`[${i + 1}] ${c.source_name || 'Quelle'}`];
+            if (typeof c.page === 'number') {
+              parts.push(`Seite ${c.page}`);
+            }
+            if (typeof c.score === 'number' && !Number.isNaN(c.score)) {
+              parts.push(`Score: ${Number(c.score).toFixed(2)}`);
+            }
+            return parts.join(' | ');
+          }).join('\n');
+          citeText = `\n\nQuellen:\n${citeLines}`;
+        }
+        addMessage('assistant', answer + citeText);
+      } catch (err) {
+        console.error(err);
+        addMessage('assistant', 'Es ist ein Fehler beim Abrufen der Antwort aufgetreten. Siehe Konsole für Details.');
       }
-      addMessage('assistant', answer + citeText);
     });
 
-    document.getElementById('reindex').addEventListener('click', async () => {
-      document.getElementById('reindex-status').textContent = '… läuft';
-      const resp = await fetch('/api/reindex', { method: 'POST' });
-      const data = await resp.json();
-      document.getElementById('reindex-status').textContent = `OK – ${data.indexed_chunks} Chunks`;
+    const reindexButton = document.getElementById('reindex');
+    const reindexStatus = document.getElementById('reindex-status');
+    reindexButton.addEventListener('click', async () => {
+      reindexButton.disabled = true;
+      reindexStatus.textContent = '… läuft';
+      try {
+        const resp = await fetch('/api/reindex', { method: 'POST' });
+        if (!resp.ok) {
+          throw new Error(`HTTP ${resp.status}`);
+        }
+        const data = await resp.json();
+        const total = typeof data.indexed_chunks === 'number' ? data.indexed_chunks : '–';
+        reindexStatus.textContent = `OK – ${total} Chunks`;
+      } catch (err) {
+        console.error(err);
+        reindexStatus.textContent = 'Fehler beim Reindex – siehe Konsole';
+      } finally {
+        reindexButton.disabled = false;
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- rewrite the ingest helper to use valid string literals and paragraph splitting
- keep support for txt, md, pdf and docx sources while generating clean chunk records

## Testing
- python -m app.ingest --data-dir data --index-path index.jsonl --reset

------
https://chatgpt.com/codex/tasks/task_e_68cd238242f88323a72796d6d79574ad